### PR TITLE
docs: add branchName and repoName as general template variables

### DIFF
--- a/src/pages/docs/features/_meta.ts
+++ b/src/pages/docs/features/_meta.ts
@@ -47,5 +47,5 @@ export default {
   },
   "mcp-integration": {
     "title": "MCP Integration"
-  },
+  }
 };

--- a/src/pages/docs/features/template-variables.mdx
+++ b/src/pages/docs/features/template-variables.mdx
@@ -7,6 +7,7 @@ tags:
   - publicUrl
   - sha
   - branchName
+  - repoName
   - UUID
   - internalHostname
   - review
@@ -27,6 +28,8 @@ The following template variables are available for use within your configuration
 - **`{{{buildUUID}}}`** - The unique identifier for the Lifecycle environment, e.g., `lively-down-881123`.
 - **`{{{namespace}}}`** - Namespace for the deployments, e.g., `env-lively-down-881123`.
 - **`{{{pullRequestNumber}}}`** - The GitHub pull request number associated with the environment.
+- **`{{{branchName}}}`** - The branch name of the pull request that triggered the environment.
+- **`{{{repoName}}}`** - The full repository name (e.g., `org/repo`) associated with the environment.
 
 ### Service-Specific Variables
 


### PR DESCRIPTION
## Fixes

- References GoodRxOSS/lifecycle#129

## Proposed Changes

- Documents `{{{branchName}}}` as a general template variable — the branch name of the pull request that triggered the environment
- Documents `{{{repoName}}}` as a general template variable — the full repository name (e.g., `org/repo`) associated with the environment

---

> Read about referenced issues [here](https://help.github.com/articles/closing-issues-using-keywords/). Replace words with this Pull Request's context.